### PR TITLE
fix: use core::iter::once for no_std compatibility

### DIFF
--- a/midi2/src/traits.rs
+++ b/midi2/src/traits.rs
@@ -613,7 +613,7 @@ pub trait Sysex<B: crate::buffer::Buffer> {
     where
         B: crate::buffer::BufferMut + crate::buffer::BufferResize,
     {
-        self.insert_payload(std::iter::once(byte), self.payload_size());
+        self.insert_payload(core::iter::once(byte), self.payload_size());
     }
 
     /// Pushes the provided byte into the back of the
@@ -629,7 +629,7 @@ pub trait Sysex<B: crate::buffer::Buffer> {
     where
         B: crate::buffer::BufferMut + crate::buffer::BufferTryResize,
     {
-        self.try_insert_payload(std::iter::once(byte), self.payload_size())
+        self.try_insert_payload(core::iter::once(byte), self.payload_size())
     }
 }
 


### PR DESCRIPTION
The `extend sysex api` commit (0bbe57f) introduced `std::iter::once` in `traits.rs`, which breaks compilation for `no_std` targets.

This replaces `std::iter::once` with `core::iter::once` (lines 616 and 632).